### PR TITLE
Add compatibility with DynamicCrosshair

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,13 @@ repositories {
 	// Mod Deps
 	maven { url "https://maven.shedaniel.me/" }
 	maven { url "https://maven.terraformersmc.com/releases/" }
+	maven {
+		name = "Modrinth"
+		url = "https://api.modrinth.com/maven"
+		content {
+			includeGroup "maven.modrinth"
+		}
+	}
 }
 
 dependencies {
@@ -52,6 +59,8 @@ dependencies {
 	}
 
 	modApi("com.terraformersmc:modmenu:${project.modmenu_version}")
+
+	modCompileOnly("maven.modrinth:dynamiccrosshair:${project.dynamiccrosshair_version}")
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,4 @@ show_dev_warnings=false
 # Dependencies
 clothconfig_version=11.0.99
 modmenu_version=7.1.0
+dynamiccrosshair_version=7.0.4+1.20

--- a/src/main/java/me/cg360/mod/bridging/compat/DynamicCrosshairCompat.java
+++ b/src/main/java/me/cg360/mod/bridging/compat/DynamicCrosshairCompat.java
@@ -1,0 +1,36 @@
+package me.cg360.mod.bridging.compat;
+
+import me.cg360.mod.bridging.BridgingMod;
+import me.cg360.mod.bridging.raytrace.BridgingStateTracker;
+import me.cg360.mod.bridging.util.GameSupport;
+import mod.crend.dynamiccrosshair.api.CrosshairContext;
+import mod.crend.dynamiccrosshair.api.DynamicCrosshairApi;
+import mod.crend.dynamiccrosshair.component.Crosshair;
+import net.minecraft.world.phys.HitResult;
+
+public class DynamicCrosshairCompat implements DynamicCrosshairApi {
+	@Override
+	public String getNamespace() {
+		return "bridgingmod";
+	}
+
+	@Override
+	public boolean forceInvalidate(CrosshairContext context) {
+		return BridgingMod.getConfig().isBridgingEnabled()
+				&& GameSupport.isHoldingPlaceable(context.player)
+				&& context.hitResult.getType() == HitResult.Type.MISS;
+	}
+
+	@Override
+	public boolean forceCheck() {
+		return true;
+	}
+
+	@Override
+	public Crosshair computeFromItem(CrosshairContext context) {
+		if (BridgingStateTracker.getLastTickTarget() != null) {
+			return Crosshair.HOLDING_BLOCK;
+		}
+		return null;
+	}
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -18,7 +18,8 @@
     "entrypoints": {
         "main": [ "me.cg360.mod.bridging.BridgingModCommon::init" ],
         "client": [ "me.cg360.mod.bridging.BridgingMod::init" ],
-        "modmenu": [ "me.cg360.mod.bridging.compat.ModMenuIntegration" ]
+        "modmenu": [ "me.cg360.mod.bridging.compat.ModMenuIntegration" ],
+        "dynamiccrosshair": [ "me.cg360.mod.bridging.compat.DynamicCrosshairCompat" ]
     },
     "mixins": [
         "${mod_id}.mixins.json"


### PR DESCRIPTION
Adds a small implementation of the DynamicCrosshair API to ensure the bridge crosshair (and also the "holding block" crosshair) gets rendered. The compat file is only loaded by DynamicCrosshair through an entrypoint, so BridgingMod can be used without DynamicCrosshair present like it has been.

Fixes #1 and Crendgrim/DynamicCrosshairCompat#21

You said you might create a pull request against DynamicCrosshairCompat.. so... UNO reverse? :)