### PR TITLE
Fix key mapping sorting

### DIFF
--- a/common/src/main/java/me/cg360/mod/bridging/BridgingKeyMappings.java
+++ b/common/src/main/java/me/cg360/mod/bridging/BridgingKeyMappings.java
@@ -13,7 +13,7 @@ import static me.cg360.mod.bridging.BridgingMod.MOD_ID;
 public class BridgingKeyMappings {
 
     private static final ArrayList<KeyMapping> KEY_MAPPINGS = new ArrayList<>();
-    private static final KeyMapping.Category CATEGORY = new KeyMapping.Category(Identifier.fromNamespaceAndPath(MOD_ID, "category"));
+    private static final KeyMapping.Category CATEGORY = KeyMapping.Category.register(Identifier.fromNamespaceAndPath(MOD_ID, "category"));
 
     public static final KeyMapping TOGGLE_BRIDGING = defineMapping(new KeyMapping("key.bridgingmod.toggle_bridging", InputConstants.Type.KEYSYM, GLFW.GLFW_KEY_COMMA, CATEGORY));
 


### PR DESCRIPTION
Key mapping categories should be created with the `register` method to ensure that Minecraft sorts them correctly. Without this, new categories are placed at the very top of the menu.
https://docs.fabricmc.net/develop/key-mappings#creating-a-key-mapping